### PR TITLE
Bugfix: Detect auto exposure as a string rather than a number

### DIFF
--- a/webcam.py
+++ b/webcam.py
@@ -106,7 +106,6 @@ async def webcam():
 							muted = False # 1 is Manual
 						else:
 							muted = True # 0, 2 and 3 are all Auto modes
-						print("Exposure:", value, muted)
 						webcams[device + "exposure"].mute.set_active(muted)
 					elif cmd == "Error" and value == "Device not found":
 						print("Device not found:", device)

--- a/webcam.py
+++ b/webcam.py
@@ -102,10 +102,11 @@ async def webcam():
 					elif cmd == "exposure_absolute":
 						webcams[device + "exposure"].refract_value(int(value), "backend")
 					elif cmd == "exposure_auto":
-						if value == 1:
+						if value == "1":
 							muted = False # 1 is Manual
 						else:
 							muted = True # 0, 2 and 3 are all Auto modes
+						print("Exposure:", value, muted)
 						webcams[device + "exposure"].mute.set_active(muted)
 					elif cmd == "Error" and value == "Device not found":
 						print("Device not found:", device)


### PR DESCRIPTION
Since the value is always a string, it will never be equal to the integer 1.